### PR TITLE
Fixed HTML syntax errors

### DIFF
--- a/src/styleGuide/styleGuide.html
+++ b/src/styleGuide/styleGuide.html
@@ -20,6 +20,7 @@
                     </div>
                 </div>
             </div>
+        </div>
     </article>
 
     <article>

--- a/src/workshops/container/container.html
+++ b/src/workshops/container/container.html
@@ -26,7 +26,7 @@
         <div class="form-group">
             <label>Vertical</label>
             <a href="#" class="toolbox-btn" role="button"
-                data-bind="click: alignTop, css: { 'toolbox-btn-is-active': verticalAlignment() === 'start' }, tooltip: 'Align top'"">
+                data-bind="click: alignTop, css: { 'toolbox-btn-is-active': verticalAlignment() === 'start' }, tooltip: 'Align top'">
                 <i aria-hidden="true" class="paperbits-icon paperbits-align-top"></i>
             </a>
             <a href="#" class="toolbox-btn" role="button"
@@ -34,7 +34,7 @@
                 <i aria-hidden="true" class="paperbits-icon paperbits-align-center-vertical"></i>
             </a>
             <a href="#" class="toolbox-btn" role="button"
-                data-bind="click: alignBottom, css: { 'toolbox-btn-is-active': verticalAlignment() === 'end' }, tooltip: 'Align bottom'"">
+                data-bind="click: alignBottom, css: { 'toolbox-btn-is-active': verticalAlignment() === 'end' }, tooltip: 'Align bottom'">
                 <i aria-hidden="true" class="paperbits-icon paperbits-align-bottom"></i>
             </a>
         </div>

--- a/src/workshops/transform/transform.html
+++ b/src/workshops/transform/transform.html
@@ -18,7 +18,7 @@
         </div>
         <div class="form-group">
             <label for="scaleX">Scale X</label>
-            <input id="scaleeX" type="number" class="form-control" placeholder="(Inherit)"
+            <input id="scaleX" type="number" class="form-control" placeholder="(Inherit)"
                 data-bind="textInput: $component.scaleX" />
         </div>
         <div class="form-group">
@@ -31,6 +31,5 @@
             <input id="rotate" type="number" class="form-control" placeholder="(Inherit)"
                 data-bind="textInput: $component.rotate" />
         </div>
-    </div>
     </div>
 </div>


### PR DESCRIPTION
Hi, I've found some minor invalid HTML in the project. 
This PR adds a missing closing _div_, removes two spurious double quotes and amends a typo in an id attribute.