### PR TITLE
Rounding the RGB components emitted from Pickr

### DIFF
--- a/src/ko/bindingHandlers/bindingHandlers.colorPicker.ts
+++ b/src/ko/bindingHandlers/bindingHandlers.colorPicker.ts
@@ -31,7 +31,7 @@ ko.bindingHandlers["colorPicker"] = {
 
         pickr.on("change", (color: any) => {
             if (config.selectedColor) {
-                config.selectedColor(color.toRGBA().toString());
+                config.selectedColor(color.toRGBA().toString(0)); // round to integer with toString(precision)
             }
         });
     }


### PR DESCRIPTION
Choosing a color with the color picker can generate values such as:
`rgba(117.99999999999999, 117.99999999999999, 117.99999999999999, 0.5)`
The first three components should probably be truncated to the nearest integer.
Pickr's `RoundableNumberArray.toString(precision: number)` methot should do the trick:
`rgba(118, 118, 118, 0.5)`