### PR TITLE
Update typography values in different states

### DIFF
--- a/src/workshops/typography/typography.ts
+++ b/src/workshops/typography/typography.ts
@@ -164,7 +164,7 @@ export class Typography {
         this.textAlign.extend(ChangeRateLimit).subscribe(this.applyChanges);
         this.textTransform.extend(ChangeRateLimit).subscribe(this.applyChanges);
         this.textDecoration.extend(ChangeRateLimit).subscribe(this.applyChanges);
-        this.typography.extend(ChangeRateLimit).subscribe(this.updateObservables);
+        this.typography.subscribe(this.updateObservables);
     }
 
     public async onFontSelected(fontContract: FontContract): Promise<void> {


### PR DESCRIPTION
**Steps to reproduce:**
1. Open the editor for a button (or any control that allows changing states styles)
2. Select "hover" state
3. Change the text color

**Expected behavior:**
The text color should be changed to the selected one for the specific control

**Actual behavior:**
The text color is changed briefly, but then it switches back to the original one

![hover color](https://user-images.githubusercontent.com/92857141/163204841-e6bae3c0-3ebe-447e-85a9-6cc6bf69f01f.gif)

**Notes:**
1. For the "default" state it works normally, and, after changing the color for the default state, it will work for other states too.
2. It reproduces for other typography values too (font weight, font style, etc.)

**Problem:**
Because of the re-limit extender, the method updateObservables() from typography.ts is called recursively and it creates a loop that keeps updating the typography values to the previously selected ones.

