### PR TITLE
Fixed: merge newly added colors into global styles

### DIFF
--- a/src/defaultStyleCompiler.ts
+++ b/src/defaultStyleCompiler.ts
@@ -579,7 +579,7 @@ export class DefaultStyleCompiler implements StyleCompiler {
         }
 
         if (widgetHandlerClass) {
-            this.backfillLocalStyles(widgetHandlerClass, localStyles);
+            await this.backfillLocalStyles(widgetHandlerClass, localStyles);
         }
 
         localStyles = Objects.clone(localStyles); // To drop any object references
@@ -715,7 +715,7 @@ export class DefaultStyleCompiler implements StyleCompiler {
         return css;
     }
 
-    public backfillLocalStyles(handlerClass: any, localStyles: LocalStyles): void {
-        this.styleService.backfillLocalStyles(handlerClass, localStyles);
+    public async backfillLocalStyles(handlerClass: any, localStyles: LocalStyles): Promise<void> {
+        await this.styleService.backfillLocalStyles(handlerClass, localStyles);
     }
 }

--- a/src/styleService.ts
+++ b/src/styleService.ts
@@ -462,7 +462,12 @@ export class StyleService {
             });
         });
 
-        this.updateStyles(styles);
+        await new Promise<void>((resolve) => {
+            setTimeout(async () => {
+                await this.mergeStyles(styles);
+                resolve();
+            }, 0);
+        });
     }
 
     public async backfillStyles(): Promise<void> {


### PR DESCRIPTION
Closes #18 

When there are multiple customizable widgets on the same page that contain colors in their style definitions, they are loaded asynchronously and overwrite the colors saved in the global styles. This way, a race condition is produced, each widget overriding the other widgets' changes to the global styles and, at the end, there colors added are just from one of the widgets.

Widget1 introduces color1: after updating the styles, the list of colors contains color1.
Widget2 introduces color2: when updating the styles, the old styles (that are being currently updated) do not contain color1; after the update, global styles will only contain color2.